### PR TITLE
Fix: Check if main-img exists before figure tag

### DIFF
--- a/layouts/partials/featured-minor.html
+++ b/layouts/partials/featured-minor.html
@@ -10,9 +10,11 @@
     <div class="sbox">
         {{- .Scratch.Set "imageref" "minor-img" -}}
         {{- $idata := partial "_main_img_map.html" . -}}
+        {{- if $idata -}}
         <figure>
             <img src="{{ index $idata "link" }}" alt="{{ index $idata "alt"}}">
         </figure>
+        {{- end -}}
         <h2>
             {{ .Title }}
         </h2>


### PR DESCRIPTION
It was trowing an error when the feature-minor page didn't have a main-img