### PR TITLE
Fix undeclared variable error - Hugo v0.98

### DIFF
--- a/layouts/partials/figure.html
+++ b/layouts/partials/figure.html
@@ -2,6 +2,7 @@
 {{- $link := index . "link" -}}
 {{- $id := partial "_image_id.html" $link -}}
 {{- $klass := index . "klass" -}}
+{{- $authors := index . "authors" -}}
 <figure class="prominent {{ $klass }}" id="{{ $id }}" itemprop="image" itemscope itemtype="http://schema.org/ImageObject">
     <link itemprop="url" href="{{ $link }}" rel="preload" as="image"> 
     <img itemprop="image" src="{{ $link }}" alt="{{ index . "alt" }}" onclick="expandPic(event, 'expanded')">


### PR DESCRIPTION
On Hugo v0.98 I got the following error when running hugo on my personal project:

```bash
Error: Error building site: failed to render pages: render of "page" failed: execute of template failed: template: _default/single.html:26:15: executing "main" at <partial "main_img.html" .>: error calling partial: execute of template failed: template: partials/main_img.html:2:4: executing "partials/main_img.html" at <partial "figure.html" (partial "_main_img_map.html" .)>: error calling partial: "/home/mgm/projects/personal/mateusmeloxyz-errorist/layouts/partials/figure.html:13:29": execute of template failed: template: partials/figure.html:13:29: executing "partials/figure.html" at <$authors>: undefined variable: $authors
Built in 226 ms
```

I think it was probably being caused by the `{{- if or ( $cap := index . "cap" ) ( $authors := index . "authors" ) -}}` only excetuting the first statement in the case that a picture has no authors. I made the change above and it fixed the error.